### PR TITLE
Fix filenignore behavior for directories

### DIFF
--- a/src/lib/deltas.ts
+++ b/src/lib/deltas.ts
@@ -494,6 +494,7 @@ export class Deltas {
 			.sort((a, b) => a.path.split("/").length - b.path.split("/").length)
 			// Filter by ignored paths
 			.filter(delta => {
+				const trailingSlash = delta.type.endsWith("Directory") ? "/" : ""
 				if (
 					delta.type === "renameLocalDirectory" ||
 					delta.type === "renameLocalFile" ||
@@ -504,7 +505,7 @@ export class Deltas {
 						return false
 					}
 
-					if (this.sync.ignorer.ignores(delta.from) || this.sync.ignorer.ignores(delta.to)) {
+					if (this.sync.ignorer.ignores(delta.from + trailingSlash) || this.sync.ignorer.ignores(delta.to + trailingSlash)) {
 						return false
 					}
 				} else {
@@ -512,7 +513,7 @@ export class Deltas {
 						return false
 					}
 
-					if (this.sync.ignorer.ignores(delta.path)) {
+					if (this.sync.ignorer.ignores(delta.path + trailingSlash)) {
 						return false
 					}
 				}

--- a/src/lib/filesystems/remote.ts
+++ b/src/lib/filesystems/remote.ts
@@ -184,7 +184,8 @@ export class RemoteFileSystem {
 			}
 		}
 
-		if (this.sync.ignorer.ignores(relativePath)) {
+		const trailingSlash = type === "directory" ? "/" : ""
+		if (this.sync.ignorer.ignores(relativePath + trailingSlash)) {
 			this.ignoredCache.set(key, {
 				ignored: true,
 				reason: "filenIgnore"


### PR DESCRIPTION
As by gitignore syntax, directories are differentiated from files by specifying a trailing slash.
```
any_directory/
any_file
/specific/directory/
/specific/file
```
Filen's sync does not meet these specifications and fails to match entries with trailing slash. Instead, for the example above, Filen would not ignore the directories until removing the trailing slash. Although seemingly not a big problem, it is **not the gititnore behavior** and [may lead to confusion and frustration](https://discord.com/channels/724449174334078996/724450150390693989/1315988224195166208).

The reason is [laid out in the README ("2. filenames and dirnames")](https://www.npmjs.com/package/ignore#user-content-2-filenames-and-dirnames) of the used package `ignore`: The package cannot tell files and directories apart given the file path as simple string and requires a trailing slash to do so.

Here, I attempted to remedy this behavior at the relevant portions in the code that I could find by passing a trailing slash to the `ignores` function. Most likely that is not done in the most performant and elegant way. Nevertheless, I hope it will inspire to address this minor issue.